### PR TITLE
Added a check for AllowAnonymous on the custom authorize attribute

### DIFF
--- a/Helpers/AuthorizeAttribute.cs
+++ b/Helpers/AuthorizeAttribute.cs
@@ -2,6 +2,9 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using System;
+using System.Linq;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.Controllers;
 using WebApi.Entities;
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
@@ -9,6 +12,21 @@ public class AuthorizeAttribute : Attribute, IAuthorizationFilter
 {
     public void OnAuthorization(AuthorizationFilterContext context)
     {
+        // We're checking here to see if the route has been decorated with an [AllowAnonymous] attribute. If it has, we skip authorization
+        // for the route. Doing this allows us to apply the [Authorize] attribute by default in the startup using:
+        //
+        // services.AddControllers().AddMvcOptions(x => x.Filters.Add(new AuthorizeAttribute()))
+        //
+        if (context.ActionDescriptor is ControllerActionDescriptor controllerActionDescriptor)
+        {
+            var hasAllowAnonymousAttribute = controllerActionDescriptor.MethodInfo.GetCustomAttributes(inherit: true)
+                .Any(a => a.GetType() == typeof(AllowAnonymousAttribute));
+            if (hasAllowAnonymousAttribute)
+            {
+                return;
+            }
+        }
+        
         var user = (User)context.HttpContext.Items["User"];
         if (user == null)
         {

--- a/Startup.cs
+++ b/Startup.cs
@@ -20,7 +20,9 @@ namespace WebApi
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddCors();
-            services.AddControllers();
+            services.AddControllers()
+                //.AddMvcOptions(x => x.Filters.Add(new AuthorizeAttribute())) //Uncomment this line to add the authorize attribute to all route by default
+                ;
 
             // configure strongly typed settings object
             services.Configure<AppSettings>(Configuration.GetSection("AppSettings"));


### PR DESCRIPTION
Hi Jason

This is a modification of the custom `AuthorizeAttribute` so that checks for an `[AllowAnonymous]` attribute on the route. It allows you to add `[Authorize]` to all routes by default, and then 'unauthorize' specific routes. Let me know if this is useful.

Chris Hodges